### PR TITLE
Respect last window state

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     }
   },
   "dependencies": {
+    "electron-window-state": "^4.1.1",
     "request": "^2.81.0",
     "request-promise": "^4.2.1"
   },


### PR DESCRIPTION
This updates the main window's initialisation code to remember the window state from the previous time the app was used, using the `electron-window-state` helper.

Rather than maximising every time the application starts, it will instead start at 1000 by 800, and subsequently open in whichever size the user last used it in.

This fixes #47.